### PR TITLE
Added option to display alarm times in AM/PM (12 hour) format

### DIFF
--- a/data/alarm-clock.schemas.in
+++ b/data/alarm-clock.schemas.in
@@ -19,6 +19,19 @@
             </locale>
         </schema>
     	
+    	<schema>
+            <key>/schemas/apps/alarm-clock/time_format_12h</key>
+            <applyto>/apps/alarm-clock/time_format_12h</applyto>
+            <owner>alarm-clock</owner>
+            <type>bool</type>
+            <default>false</default>
+            <locale name="C">
+                <short>Use AM/PM format for alarms</short>
+                <long>Whether to use 12 hour (am/pm) or 24 hour format when 
+                      setting alarm times.</long>
+            </locale>
+        </schema>
+
     	<!--
     	Alarm specific:
     	-->

--- a/data/alarm-clock.ui
+++ b/data/alarm-clock.ui
@@ -2,15 +2,26 @@
 <interface>
   <requires lib="gtk+" version="2.16"/>
   <!-- interface-naming-policy project-wide -->
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">99</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="upper">59</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment4">
-    <property name="upper">23</property>
+    <property name="upper">24</property>
+    <property name="value">1</property>
     <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustment5">
     <property name="lower">1</property>
@@ -19,12 +30,10 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkAction" id="delete-action">
-    <property name="label" translatable="yes">Delete alarm</property>
-    <property name="short_label" translatable="yes">Delete</property>
-    <property name="tooltip" translatable="yes">Delete the selected alarm</property>
-    <property name="stock_id">gtk-delete</property>
-    <signal name="activate" handler="alarm_action_delete" swapped="no"/>
+  <object class="GtkToggleAction" id="autostart-action">
+    <property name="label" translatable="yes">Start automatically at login</property>
+    <property name="short_label" translatable="yes">Start automatically at login</property>
+    <signal name="activate" handler="alarm_action_toggle_autostart" swapped="no"/>
   </object>
   <object class="GtkAction" id="edit-action">
     <property name="label" translatable="yes">Edit alarm</property>
@@ -39,6 +48,11 @@
     <property name="tooltip" translatable="yes">Enable/disable the selected alarm</property>
     <property name="stock_id">gtk-yes</property>
     <signal name="activate" handler="alarm_action_enabled" swapped="no"/>
+  </object>
+  <object class="GtkToggleAction" id="hour-format-action">
+    <property name="label" translatable="yes">Use AM/PM format for alarm times</property>
+    <property name="short_label" translatable="yes">Use AM/PM format for alarm times</property>
+    <signal name="activate" handler="alarm_action_toggle_time_format_12h" swapped="no"/>
   </object>
   <object class="GtkAction" id="new-action">
     <property name="label" translatable="yes">New alarm</property>
@@ -142,16 +156,6 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">99</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment2">
-    <property name="upper">59</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
   </object>
   <object class="GtkWindow" id="alarm-list-window">
     <property name="can_focus">False</property>
@@ -593,6 +597,21 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="am-pm-button">
+                    <property name="label" translatable="yes">AM</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="use_action_appearance">False</property>
+                    <signal name="clicked" handler="am_pm_button_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
@@ -1150,10 +1169,26 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
     </columns>
     <signal name="rows-reordered" handler="alarm_list_window_rows_reordered" swapped="no"/>
   </object>
-  <object class="GtkToggleAction" id="autostart-action">
-    <property name="label" translatable="yes">Start automatically at login</property>
-    <property name="short_label" translatable="yes">Start automatically at login</property>
-    <signal name="activate" handler="alarm_action_toggle_autostart" swapped="no"/>
+  <object class="GtkListStore" id="am-pm-list">
+    <columns>
+      <!-- column-name value -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">AM</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">PM</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkAction" id="delete-action">
+    <property name="label" translatable="yes">Delete alarm</property>
+    <property name="short_label" translatable="yes">Delete</property>
+    <property name="tooltip" translatable="yes">Delete the selected alarm</property>
+    <property name="stock_id">gtk-delete</property>
+    <signal name="activate" handler="alarm_action_delete" swapped="no"/>
   </object>
   <object class="GtkImage" id="image3">
     <property name="visible">True</property>
@@ -1261,6 +1296,22 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkCheckButton" id="hour-format-check">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Use 12 hour format
+instead of 24 hour</property>
+                        <property name="related_action">hour-format-action</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -1297,6 +1348,7 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkCheckButton" id="show-label-check">
+                        <property name="label" translatable="yes">Show countdown label</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>

--- a/po/alarm-clock-applet.pot
+++ b/po/alarm-clock-applet.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-21 12:32-0700\n"
+"POT-Creation-Date: 2017-03-23 22:44-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Wake up in the morning"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:1 ../data/alarm-clock.ui.h:14
+#: ../data/alarm-clock.schemas.in.h:1 ../data/alarm-clock.ui.h:13
 msgid "Show countdown label"
 msgstr ""
 
@@ -37,69 +37,78 @@ msgid ""
 msgstr ""
 
 #: ../data/alarm-clock.schemas.in.h:3
-msgid "Alarm Type"
+msgid "Use AM/PM format for alarms"
 msgstr ""
 
 #: ../data/alarm-clock.schemas.in.h:4
+msgid ""
+"Whether to use 12 hour (am/pm) or 24 hour format when setting alarm times."
+msgstr ""
+
+#: ../data/alarm-clock.schemas.in.h:5
+msgid "Alarm Type"
+msgstr ""
+
+#: ../data/alarm-clock.schemas.in.h:6
 msgid ""
 "The type of the alarm. Either \"clock\" for an alarm at a specific time of "
 "day, or \"timer\" for an alarm after a specified period of time."
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:5
+#: ../data/alarm-clock.schemas.in.h:7
 msgid "Alarm Timestamp"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:6
+#: ../data/alarm-clock.schemas.in.h:8
 msgid ""
 "The UNIX timestamp for the alarm. Must be set before the alarm is activated."
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:7
+#: ../data/alarm-clock.schemas.in.h:9
 msgid "Alarm Time"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:8
+#: ../data/alarm-clock.schemas.in.h:10
 msgid ""
 "The time for the alarm. Should be in GMT for \"clock\" alarms or length in "
 "seconds for \"timer\" alarms."
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:9
+#: ../data/alarm-clock.schemas.in.h:11
 msgid "Alarm!"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:10
+#: ../data/alarm-clock.schemas.in.h:12
 msgid "Alarm Message"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:11
+#: ../data/alarm-clock.schemas.in.h:13
 msgid "A short message which describes the alarm."
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:12
+#: ../data/alarm-clock.schemas.in.h:14
 msgid "Alarm Running State"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:13
+#: ../data/alarm-clock.schemas.in.h:15
 msgid "Indicates whether the alarm has started."
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:14
+#: ../data/alarm-clock.schemas.in.h:16
 msgid "Alarm Repeat"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:15
+#: ../data/alarm-clock.schemas.in.h:17
 msgid ""
 "A list of days when the alarm should be repeated. This settings is only "
 "applicable for \"clock\" alarms."
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:16
+#: ../data/alarm-clock.schemas.in.h:18
 msgid "Notification Type"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:17
+#: ../data/alarm-clock.schemas.in.h:19
 msgid ""
 "The type of notification to use when the alarm goes off. This can be one of "
 "the following: \"sound\" to play a sound (specified in the \"sound_file\" "
@@ -107,156 +116,156 @@ msgid ""
 "property.)"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:18
+#: ../data/alarm-clock.schemas.in.h:20
 msgid "Sound File"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:19
+#: ../data/alarm-clock.schemas.in.h:21
 msgid "The sound file to play for the \"sound\" notification type."
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:20
+#: ../data/alarm-clock.schemas.in.h:22
 msgid "Repeat Sound"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:21
+#: ../data/alarm-clock.schemas.in.h:23
 msgid "Whether to repeat the alarm sound."
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:22
+#: ../data/alarm-clock.schemas.in.h:24
 msgid "Command"
 msgstr ""
 
-#: ../data/alarm-clock.schemas.in.h:23
+#: ../data/alarm-clock.schemas.in.h:25
 msgid "The command to run for the \"command\" notification type."
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:1
-msgid "Delete alarm"
+msgid "Start automatically at login"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:2
-msgid "Delete"
-msgstr ""
-
-#: ../data/alarm-clock.ui.h:3
-msgid "Delete the selected alarm"
-msgstr ""
-
-#: ../data/alarm-clock.ui.h:4
 msgid "Edit alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:5
+#: ../data/alarm-clock.ui.h:3
 msgid "Edit..."
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:6
+#: ../data/alarm-clock.ui.h:4
 msgid "Edit the selected alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:7
+#: ../data/alarm-clock.ui.h:5
 msgid "Enable/disable alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:8
+#: ../data/alarm-clock.ui.h:6
 msgid "Enable/disable"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:9
+#: ../data/alarm-clock.ui.h:7
 msgid "Enable/disable the selected alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:10
+#: ../data/alarm-clock.ui.h:8
+msgid "Use AM/PM format for alarm times"
+msgstr ""
+
+#: ../data/alarm-clock.ui.h:9
 msgid "New alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:11
+#: ../data/alarm-clock.ui.h:10
 msgid "New"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:12
+#: ../data/alarm-clock.ui.h:11
 msgid "_Quit"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:13
+#: ../data/alarm-clock.ui.h:12
 msgid "Quit Alarm Clock"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:15
+#: ../data/alarm-clock.ui.h:14
 msgid "Snooze alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:16
+#: ../data/alarm-clock.ui.h:15
 msgid "Snooze"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:17
+#: ../data/alarm-clock.ui.h:16
 msgid "Snooze the selected alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:18
+#: ../data/alarm-clock.ui.h:17
 msgid "Snooze all alarms"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:19
+#: ../data/alarm-clock.ui.h:18
 msgid "Snooze alarms"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:20
+#: ../data/alarm-clock.ui.h:19
 msgid "Snooze all beeping alarms"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:21
+#: ../data/alarm-clock.ui.h:20
 msgid "Stop alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:22
+#: ../data/alarm-clock.ui.h:21
 msgid "Stop"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:23
+#: ../data/alarm-clock.ui.h:22
 msgid "Stop the selected alarm"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:24
+#: ../data/alarm-clock.ui.h:23
 msgid "Stop all alarms"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:25
+#: ../data/alarm-clock.ui.h:24
 msgid "Stop alarms"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:26
+#: ../data/alarm-clock.ui.h:25
 msgid "Stop all beeping alarms"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:27
+#: ../data/alarm-clock.ui.h:26
 msgid "Toggle alarms window"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:28
+#: ../data/alarm-clock.ui.h:27
 msgid "Toggle alarms"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:29
+#: ../data/alarm-clock.ui.h:28
 msgid "Toggle the visibility of the alarms window"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:30
+#: ../data/alarm-clock.ui.h:29
 msgid "About Alarm Clock"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:31
+#: ../data/alarm-clock.ui.h:30
 msgid "Get up in the morning!"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:32
+#: ../data/alarm-clock.ui.h:31
 msgid "Alarms"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:33
+#: ../data/alarm-clock.ui.h:32
 msgid "New..."
+msgstr ""
+
+#: ../data/alarm-clock.ui.h:33
+msgid "Delete"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:34
@@ -268,142 +277,160 @@ msgid "Timer"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:37
-msgid "Wake up sleepy head!"
+msgid "AM"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:38
-msgid "_Time:"
+msgid "Wake up sleepy head!"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:39
-msgid "_Name:"
+msgid "_Time:"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:40
-msgid "Mon"
+msgid "_Name:"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:41
-msgid "Tue"
+msgid "Mon"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:42
-msgid "Wed"
+msgid "Tue"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:43
-msgid "Thu"
+msgid "Wed"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:44
-msgid "Fri"
+msgid "Thu"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:45
-msgid "Sat"
+msgid "Fri"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:46
-msgid "Sun"
+msgid "Sat"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:47
-msgid "Every Day"
+msgid "Sun"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:48 ../src/alarm.c:2009
+#: ../data/alarm-clock.ui.h:48 ../src/alarm.c:2015
+msgid "Every day"
+msgstr ""
+
+#: ../data/alarm-clock.ui.h:49 ../src/alarm.c:2009
 msgid "Weekdays"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:49 ../src/alarm.c:2012
+#: ../data/alarm-clock.ui.h:50 ../src/alarm.c:2012
 msgid "Weekends"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:50 ../src/alarm.c:2006
+#: ../data/alarm-clock.ui.h:51 ../src/alarm.c:2006
 msgid "Once"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:51
+#: ../data/alarm-clock.ui.h:52
 msgid "_Repeat:"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:52
+#: ../data/alarm-clock.ui.h:53
 msgid "Alert"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:53
+#: ../data/alarm-clock.ui.h:54
 msgid "Play _sound"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:54
+#: ../data/alarm-clock.ui.h:55
 msgid "Repea_t sound"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:55
+#: ../data/alarm-clock.ui.h:56
 msgid "Start _Application"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:56
+#: ../data/alarm-clock.ui.h:57
 msgid "Co_mmand:"
 msgstr ""
 
-#: ../data/alarm-clock.ui.h:57
-msgid "Start automatically at login"
-msgstr ""
-
 #: ../data/alarm-clock.ui.h:58
-msgid "Alarm Clock Preferences"
+msgid "PM"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:59
-msgid "General"
+msgid "Delete alarm"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:60
-msgid "Appearance"
+msgid "Delete the selected alarm"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:61
-msgid "_Snooze"
+msgid "Alarm Clock Preferences"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:62
-msgid "Snooze for:"
+msgid "General"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:63
-msgid "minutes"
-msgstr ""
-
-#: ../data/alarm-clock.ui.h:64
-msgid "1 minute"
+msgid ""
+"Use 12 hour format\n"
+"instead of 24 hour"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:65
-msgid "3 minutes"
+msgid "Appearance"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:66
-msgid "5 minutes"
+msgid "_Snooze"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:67
-msgid "10 minutes"
+msgid "Snooze for:"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:68
-msgid "Custom..."
+msgid "minutes"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:69
-msgid "Show _alarms"
+msgid "1 minute"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:70
-msgid "Manage your alarms"
+msgid "3 minutes"
 msgstr ""
 
 #: ../data/alarm-clock.ui.h:71
+msgid "5 minutes"
+msgstr ""
+
+#: ../data/alarm-clock.ui.h:72
+msgid "10 minutes"
+msgstr ""
+
+#: ../data/alarm-clock.ui.h:73
+msgid "Custom..."
+msgstr ""
+
+#: ../data/alarm-clock.ui.h:74
+msgid "Show _alarms"
+msgstr ""
+
+#: ../data/alarm-clock.ui.h:75
+msgid "Manage your alarms"
+msgstr ""
+
+#: ../data/alarm-clock.ui.h:76
 msgid "_Preferences"
 msgstr ""
 
@@ -412,25 +439,21 @@ msgstr ""
 msgid "%s is already running, exiting...\n"
 msgstr ""
 
-#: ../src/alarm-settings.c:94
+#: ../src/alarm-settings.c:98
 #, c-format
 msgid "_Repeat: %s"
 msgstr ""
 
-#: ../src/alarm-settings.c:260 ../src/alarm-settings.c:440
+#: ../src/alarm-settings.c:305 ../src/alarm-settings.c:485
 msgid "Select sound file..."
 msgstr ""
 
-#: ../src/alarm-settings.c:310
+#: ../src/alarm-settings.c:355
 msgid "Custom command..."
 msgstr ""
 
-#: ../src/alarm-settings.c:839 ../src/alarm.c:1685
+#: ../src/alarm-settings.c:928 ../src/alarm.c:1685
 msgid "Could not create player! Please check your sound settings."
-msgstr ""
-
-#: ../src/alarm.c:2015
-msgid "Every day"
 msgstr ""
 
 #. About Alarm Clock
@@ -453,6 +476,6 @@ msgstr ""
 msgid "You can snooze or stop alarms from the Alarm Clock menu."
 msgstr ""
 
-#: ../src/prefs.c:419
+#: ../src/prefs.c:431
 msgid "Requires application indicators"
 msgstr ""

--- a/src/alarm-actions.c
+++ b/src/alarm-actions.c
@@ -24,6 +24,7 @@
 #include "alarm-actions.h"
 #include "alarm-applet.h"
 #include "alarm-list-window.h"
+#include "alarm-settings.h"
 
 #define GET_ACTION(name) GTK_ACTION (gtk_builder_get_object (builder, (name)))
 
@@ -65,6 +66,7 @@ alarm_applet_actions_init (AlarmApplet *applet)
 
     applet->action_toggle_autostart = GTK_TOGGLE_ACTION (GET_ACTION ("autostart-action"));
     applet->action_toggle_show_label = GTK_TOGGLE_ACTION (GET_ACTION ("show-label-action"));
+    applet->action_toggle_time_format_12h = GTK_TOGGLE_ACTION (GET_ACTION ("hour-format-action"));
 
     gtk_action_group_add_action (applet->actions_global, applet->action_new);
     gtk_action_group_add_action (applet->actions_global, applet->action_stop_all);
@@ -73,6 +75,7 @@ alarm_applet_actions_init (AlarmApplet *applet)
         GTK_ACTION (applet->action_toggle_list_win), "Escape");
     gtk_action_group_add_action (applet->actions_global, GTK_ACTION (applet->action_toggle_autostart));
     gtk_action_group_add_action (applet->actions_global, GTK_ACTION (applet->action_toggle_show_label));
+    gtk_action_group_add_action (applet->actions_global, GTK_ACTION (applet->action_toggle_time_format_12h));
 
     gtk_action_connect_accelerator (GTK_ACTION (applet->action_toggle_list_win));
     
@@ -364,12 +367,28 @@ alarm_action_toggle_show_label (GtkAction *action, gpointer data)
 	}
 }
 
+/*
+ * Toggle time format (24-hour vs 12-hour)
+ */
+void
+alarm_action_toggle_time_format_12h (GtkAction *action, gpointer data)
+{
+    AlarmApplet *applet = (AlarmApplet *)data;
+    gboolean active = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    gboolean time_format_state = prefs_time_format_12h_get(applet);
+    AlarmSettingsDialog *settings_dialog = applet->settings_dialog;
 
+    g_debug ("AlarmAction: toggle time_format_12h to %d", active);
 
+    if (active != time_format_state) {
+        g_debug ("AlarmAction: set time_format_12h to %d!", active);
+        prefs_time_format_12h_set (applet, active);
 
-
-
-
+        // update the time display format if a settings dialog is open for an alarm
+        if (settings_dialog->alarm != NULL)
+            alarm_settings_update_time_format (settings_dialog);
+    }
+}
 
 /**
  * Update actions to a consistent state

--- a/src/alarm-actions.h
+++ b/src/alarm-actions.h
@@ -72,4 +72,7 @@ alarm_action_toggle_autostart (GtkAction *action, gpointer data);
 void
 alarm_action_toggle_show_label (GtkAction *action, gpointer data);
 
+void
+alarm_action_toggle_time_format_12h (GtkAction *action, gpointer data);
+
 #endif // ALARM_ACTIONS_H

--- a/src/alarm-applet.h
+++ b/src/alarm-applet.h
@@ -127,6 +127,7 @@ struct _AlarmApplet {
     GtkToggleAction *action_toggle_list_win;
     GtkToggleAction *action_toggle_autostart;
     GtkToggleAction *action_toggle_show_label;
+    GtkToggleAction *action_toggle_time_format_12h;
 };
 
 void alarm_applet_sounds_load (AlarmApplet *applet);

--- a/src/alarm-list-window.c
+++ b/src/alarm-list-window.c
@@ -26,6 +26,7 @@
 #include "alarm-list-window.h"
 #include "alarm-settings.h"
 #include "alarm-actions.h"
+#include "prefs.h"
 
 gboolean
 alarm_list_window_delete_event (GtkWidget *window, GdkEvent *event, gpointer data);
@@ -252,9 +253,15 @@ alarm_list_window_update_row (AlarmListWindow *list_window, GtkTreeIter *iter)
         tm = alarm_get_time (a);
     }
     
+    gboolean time_format_12h = prefs_time_format_12h_get (list_window->applet);
+
     if (a->type == ALARM_TYPE_CLOCK) {
         type_col = ALARM_ICON;
-        time_format = TIME_COL_CLOCK_FORMAT;
+        // show 12 hour format if enabled and not counting down
+        if (time_format_12h && !a->active)
+            time_format = TIME_COL_CLOCK_FORMAT_12HR;
+        else
+            time_format = TIME_COL_CLOCK_FORMAT;
     } else {
         type_col = TIMER_ICON;
         time_format = TIME_COL_TIMER_FORMAT;

--- a/src/alarm-list-window.h
+++ b/src/alarm-list-window.h
@@ -73,6 +73,7 @@ struct _AlarmListWindow {
 
 //#define TIME_COL_FORMAT "<span font='Bold 11'>%H:%M:%S</span>"
 // TODO: Does fixing the font size give a11y problems?
+#define TIME_COL_CLOCK_FORMAT_12HR "<span font='Bold 11'> %I:%M</span><span font='Bold 7'>:%S</span><span font='Bold 8'> %p</span>"
 #define TIME_COL_CLOCK_FORMAT "<span font='Bold 11'> %H:%M</span><span font='Bold 7'>:%S</span>"
 #define TIME_COL_TIMER_FORMAT "<span font='Bold 11'>-%H:%M</span><span font='Bold 7'>:%S</span>"
 #define TIME_COL_REPEAT_FORMAT "\n <sup>%s</sup>"

--- a/src/alarm-settings.h
+++ b/src/alarm-settings.h
@@ -42,8 +42,8 @@ struct _AlarmSettingsDialog {
 	GtkWidget *dialog;
 	GtkWidget *clock_toggle, *timer_toggle;
 	GtkWidget *label_entry;
-	GtkWidget *hour_spin, *min_spin, *sec_spin;
-	
+	GtkWidget *hour_spin, *min_spin, *sec_spin, *am_pm_button;
+    
 	/* Repeat */
 	GtkWidget *repeat_expand;
 	GtkWidget *repeat_label;
@@ -85,5 +85,8 @@ alarm_settings_sound_preview (GtkButton *button, gpointer data);
 
 void
 alarm_settings_dialog_response (GtkDialog *dialog, gint rid, gpointer data);
+
+void
+alarm_settings_update_time_format (AlarmSettingsDialog *dialog);
 
 #endif /*EDITALARM_H_*/

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -26,6 +26,8 @@
 
 #include "alarm-applet.h"
 
+#define TIME_FORMAT_12H_DEFAULT FALSE
+
 void
 prefs_init (AlarmApplet *applet);
 
@@ -43,5 +45,12 @@ prefs_show_label_get (AlarmApplet *applet);
 
 void
 prefs_show_label_set (AlarmApplet *applet, gboolean state);
+
+gboolean
+prefs_time_format_12h_get (AlarmApplet *applet);
+
+void
+prefs_time_format_12h_set (AlarmApplet *applet, gboolean state);
+
 
 #endif /*PREFS_H_*/

--- a/src/util.h
+++ b/src/util.h
@@ -75,5 +75,17 @@ unblock_list (GList *instances, gpointer func);
     g_signal_handlers_unblock_matched ((instance),            \
                                        G_SIGNAL_MATCH_FUNC,   \
                                        0, 0, NULL, (func), NULL)
+                                       
+/* Converts hour from 12 hour format (am/pm) to 24 hour format */
+#define HOUR_12_TO_24(hour, is_pm) \
+    is_pm ? (hour != 12 ? hour + 12 : hour) : (hour == 12 ? 0 : hour)
+
+/* Converts hour from 24 hour format to 12 hour format (am/pm) */
+#define HOUR_24_TO_12(hour) \
+    hour > 12 ? hour - 12 : (hour < 1 ? 12 : hour);
+
+/* True if the hour (in 24 hour format) is in the PM, false if AM */
+# define IS_HOUR_PM(hour) \
+    hour > 12 ? TRUE : (hour < 12 ? FALSE : TRUE)
 
 #endif /*UTIL_H_*/


### PR DESCRIPTION
- Added the option to the preferences dialog and gconfig for alarm clocks
- Timers unchanged
- Default value is off (24 hour display)