### PR TITLE
Fixed compiler errors

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,8 @@ AM_CFLAGS =	                        \
 	-DALARM_CLOCK_DATADIR=\"$(datadir)\"            \
 	-DALARM_CLOCK_PKGDATADIR=\"$(pkgdatadir)\"      \
 	@BASE_CFLAGS@ @GTK_CFLAGS@ @GSTREAMER_CFLAGS@   \
-	@GNOME_CFLAGS@ @APP_INDICATOR_CFLAGS@ @WARN_CFLAGS@
+	@GNOME_CFLAGS@ @APP_INDICATOR_CFLAGS@ @WARN_CFLAGS@ \
+ 	-Wno-format-y2k
 
 LDADD =		\
 	@BASE_LIBS@ @GTK_LIBS@ @GSTREAMER_LIBS@         \

--- a/src/alarm-list-window.c
+++ b/src/alarm-list-window.c
@@ -236,7 +236,6 @@ alarm_list_window_update_row (AlarmListWindow *list_window, GtkTreeIter *iter)
     struct tm *tm;
     
     const gchar *type_col;
-    const gchar *time_format;    
     GString *time_col;
     gchar *label_col;
 
@@ -254,15 +253,13 @@ alarm_list_window_update_row (AlarmListWindow *list_window, GtkTreeIter *iter)
     
     if (a->type == ALARM_TYPE_CLOCK) {
         type_col = ALARM_ICON;
-        time_format = TIME_COL_CLOCK_FORMAT;
+        strftime(tmp, sizeof(tmp), TIME_COL_CLOCK_FORMAT, tm);
     } else {
         type_col = TIMER_ICON;
-        time_format = TIME_COL_TIMER_FORMAT;
+        strftime(tmp, sizeof(tmp), TIME_COL_TIMER_FORMAT, tm);
     }
 
     // Create time column
-    strftime(tmp, sizeof(tmp), time_format, tm);
-
     time_col = g_string_new (tmp);
     if (a->type == ALARM_TYPE_CLOCK && a->repeat != ALARM_REPEAT_NONE) {
         tmp2 = alarm_repeat_to_pretty (a->repeat);


### PR DESCRIPTION
Fixed compiler error related to strftime: 
 - Must use a string literal as the format for security reasons
Updated src/Makefile.am to disable y2k checks (gcc errors)