### PR TITLE
Added AM/PM time format option

### DIFF
--- a/data/alarm-clock.schemas.in
+++ b/data/alarm-clock.schemas.in
@@ -19,6 +19,19 @@
             </locale>
         </schema>
     	
+        <schema>
+            <key>/schemas/apps/alarm-clock/time_format_12h</key>
+            <applyto>/apps/alarm-clock/time_format_12h</applyto>
+            <owner>alarm-clock</owner>
+            <type>bool</type>
+            <default>false</default>
+            <locale name="C">
+                <short>Use AM/PM format for alarms</short>
+                <long>Whether to use 12 hour (am/pm) or 24 hour format when
+                      setting alarm times.</long>
+            </locale>
+        </schema>
+
     	<!--
     	Alarm specific:
     	-->
@@ -162,5 +175,3 @@
 		-->
 	</schemalist>
 </gconfschemafile>
-		
-		

--- a/data/alarm-clock.ui
+++ b/data/alarm-clock.ui
@@ -2,15 +2,26 @@
 <interface>
   <requires lib="gtk+" version="2.16"/>
   <!-- interface-naming-policy project-wide -->
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">99</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="upper">59</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment4">
-    <property name="upper">23</property>
+    <property name="upper">24</property>
+    <property name="value">1</property>
     <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustment5">
     <property name="lower">1</property>
@@ -19,12 +30,10 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkAction" id="delete-action">
-    <property name="label" translatable="yes">Delete alarm</property>
-    <property name="short_label" translatable="yes">Delete</property>
-    <property name="tooltip" translatable="yes">Delete the selected alarm</property>
-    <property name="stock_id">gtk-delete</property>
-    <signal name="activate" handler="alarm_action_delete" swapped="no"/>
+  <object class="GtkToggleAction" id="autostart-action">
+    <property name="label" translatable="yes">Start automatically at login</property>
+    <property name="short_label" translatable="yes">Start automatically at login</property>
+    <signal name="activate" handler="alarm_action_toggle_autostart" swapped="no"/>
   </object>
   <object class="GtkAction" id="edit-action">
     <property name="label" translatable="yes">Edit alarm</property>
@@ -39,6 +48,11 @@
     <property name="tooltip" translatable="yes">Enable/disable the selected alarm</property>
     <property name="stock_id">gtk-yes</property>
     <signal name="activate" handler="alarm_action_enabled" swapped="no"/>
+  </object>
+  <object class="GtkToggleAction" id="hour-format-action">
+    <property name="label" translatable="yes">Use AM/PM format for alarm times</property>
+    <property name="short_label" translatable="yes">Use AM/PM format for alarm times</property>
+    <signal name="activate" handler="alarm_action_toggle_time_format_12h" swapped="no"/>
   </object>
   <object class="GtkAction" id="new-action">
     <property name="label" translatable="yes">New alarm</property>
@@ -142,16 +156,6 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">99</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment2">
-    <property name="upper">59</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
   </object>
   <object class="GtkWindow" id="alarm-list-window">
     <property name="can_focus">False</property>
@@ -595,6 +599,21 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkButton" id="am-pm-button">
+                    <property name="label" translatable="yes">AM</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="use_action_appearance">False</property>
+                    <signal name="clicked" handler="am_pm_button_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -821,7 +840,7 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkButton" id="repeat_all_button">
-                            <property name="label" translatable="yes">Every day</property>
+                            <property name="label" translatable="yes">Every Day</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
@@ -1150,10 +1169,26 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
     </columns>
     <signal name="rows-reordered" handler="alarm_list_window_rows_reordered" swapped="no"/>
   </object>
-  <object class="GtkToggleAction" id="autostart-action">
-    <property name="label" translatable="yes">Start automatically at login</property>
-    <property name="short_label" translatable="yes">Start automatically at login</property>
-    <signal name="activate" handler="alarm_action_toggle_autostart" swapped="no"/>
+  <object class="GtkListStore" id="am-pm-list">
+    <columns>
+      <!-- column-name value -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">AM</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">PM</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkAction" id="delete-action">
+    <property name="label" translatable="yes">Delete alarm</property>
+    <property name="short_label" translatable="yes">Delete</property>
+    <property name="tooltip" translatable="yes">Delete the selected alarm</property>
+    <property name="stock_id">gtk-delete</property>
+    <signal name="activate" handler="alarm_action_delete" swapped="no"/>
   </object>
   <object class="GtkImage" id="image3">
     <property name="visible">True</property>
@@ -1261,6 +1296,22 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkCheckButton" id="hour-format-check">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Use 12 hour format
+instead of 24 hour</property>
+                        <property name="related_action">hour-format-action</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -1297,6 +1348,7 @@ Kamal Mostafa &lt;kamal@canonical.com&gt;</property>
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkCheckButton" id="show-label-check">
+                        <property name="label" translatable="yes">Show countdown label</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>

--- a/src/alarm-actions.c
+++ b/src/alarm-actions.c
@@ -24,6 +24,7 @@
 #include "alarm-actions.h"
 #include "alarm-applet.h"
 #include "alarm-list-window.h"
+#include "alarm-settings.h"
 
 #define GET_ACTION(name) GTK_ACTION (gtk_builder_get_object (builder, (name)))
 
@@ -65,6 +66,7 @@ alarm_applet_actions_init (AlarmApplet *applet)
 
     applet->action_toggle_autostart = GTK_TOGGLE_ACTION (GET_ACTION ("autostart-action"));
     applet->action_toggle_show_label = GTK_TOGGLE_ACTION (GET_ACTION ("show-label-action"));
+    applet->action_toggle_time_format_12h = GTK_TOGGLE_ACTION (GET_ACTION ("hour-format-action"));
 
     gtk_action_group_add_action (applet->actions_global, applet->action_new);
     gtk_action_group_add_action (applet->actions_global, applet->action_stop_all);
@@ -73,6 +75,7 @@ alarm_applet_actions_init (AlarmApplet *applet)
         GTK_ACTION (applet->action_toggle_list_win), "Escape");
     gtk_action_group_add_action (applet->actions_global, GTK_ACTION (applet->action_toggle_autostart));
     gtk_action_group_add_action (applet->actions_global, GTK_ACTION (applet->action_toggle_show_label));
+    gtk_action_group_add_action (applet->actions_global, GTK_ACTION (applet->action_toggle_time_format_12h));
 
     gtk_action_connect_accelerator (GTK_ACTION (applet->action_toggle_list_win));
     
@@ -364,12 +367,28 @@ alarm_action_toggle_show_label (GtkAction *action, gpointer data)
 	}
 }
 
+/*
+ * Toggle time format (24-hour vs 12-hour)
+ */
+void
+alarm_action_toggle_time_format_12h (GtkAction *action, gpointer data)
+{
+    AlarmApplet *applet = (AlarmApplet *)data;
+    gboolean active = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+    gboolean time_format_state = prefs_time_format_12h_get(applet);
+    AlarmSettingsDialog *settings_dialog = applet->settings_dialog;
 
+    g_debug ("AlarmAction: toggle time_format_12h to %d", active);
 
+    if (active != time_format_state) {
+        g_debug ("AlarmAction: set time_format_12h to %d!", active);
+        prefs_time_format_12h_set (applet, active);
 
-
-
-
+        // update the time display format if a settings dialog is open for an alarm
+        if (settings_dialog->alarm != NULL)
+            alarm_settings_update_time_format (settings_dialog);
+    }
+}
 
 /**
  * Update actions to a consistent state

--- a/src/alarm-actions.h
+++ b/src/alarm-actions.h
@@ -72,4 +72,7 @@ alarm_action_toggle_autostart (GtkAction *action, gpointer data);
 void
 alarm_action_toggle_show_label (GtkAction *action, gpointer data);
 
+void
+alarm_action_toggle_time_format_12h (GtkAction *action, gpointer data);
+
 #endif // ALARM_ACTIONS_H

--- a/src/alarm-applet.h
+++ b/src/alarm-applet.h
@@ -132,6 +132,7 @@ struct _AlarmApplet {
     GtkToggleAction *action_toggle_list_win;
     GtkToggleAction *action_toggle_autostart;
     GtkToggleAction *action_toggle_show_label;
+    GtkToggleAction *action_toggle_time_format_12h;
 };
 
 void alarm_applet_sounds_load (AlarmApplet *applet);

--- a/src/alarm-list-window.c
+++ b/src/alarm-list-window.c
@@ -26,6 +26,7 @@
 #include "alarm-list-window.h"
 #include "alarm-settings.h"
 #include "alarm-actions.h"
+#include "prefs.h"
 
 gboolean
 alarm_list_window_delete_event (GtkWidget *window, GdkEvent *event, gpointer data);
@@ -251,9 +252,15 @@ alarm_list_window_update_row (AlarmListWindow *list_window, GtkTreeIter *iter)
         tm = alarm_get_time (a);
     }
     
+    gboolean time_format_12h = prefs_time_format_12h_get (list_window->applet);
+
     if (a->type == ALARM_TYPE_CLOCK) {
         type_col = ALARM_ICON;
-        strftime(tmp, sizeof(tmp), TIME_COL_CLOCK_FORMAT, tm);
+        // show 12 hour format if enabled and not counting down
+        if (time_format_12h && !a->active)
+            strftime(tmp, sizeof(tmp), TIME_COL_CLOCK_FORMAT_12HR, tm);
+        else
+            strftime(tmp, sizeof(tmp), TIME_COL_CLOCK_FORMAT, tm);
     } else {
         type_col = TIMER_ICON;
         strftime(tmp, sizeof(tmp), TIME_COL_TIMER_FORMAT, tm);

--- a/src/alarm-list-window.h
+++ b/src/alarm-list-window.h
@@ -73,6 +73,7 @@ struct _AlarmListWindow {
 
 //#define TIME_COL_FORMAT "<span font='Bold 11'>%H:%M:%S</span>"
 // TODO: Does fixing the font size give a11y problems?
+#define TIME_COL_CLOCK_FORMAT_12HR "<span font='Bold 11'> %I:%M</span><span font='Bold 7'>:%S</span><span font='Bold 8'> %p</span>"
 #define TIME_COL_CLOCK_FORMAT "<span font='Bold 11'> %H:%M</span><span font='Bold 7'>:%S</span>"
 #define TIME_COL_TIMER_FORMAT "<span font='Bold 11'>-%H:%M</span><span font='Bold 7'>:%S</span>"
 #define TIME_COL_REPEAT_FORMAT "\n <sup>%s</sup>"

--- a/src/alarm-settings.c
+++ b/src/alarm-settings.c
@@ -25,6 +25,7 @@
 #include "alarm-applet.h"
 #include "alarm.h"
 #include "player.h"
+#include "prefs.h"
 
 #include <glib.h>
 #include <glib-object.h>
@@ -41,6 +42,9 @@ alarm_settings_changed_type (GtkToggleButton *toggle, gpointer data);
 
 void
 alarm_settings_changed_label (GtkEditable *editable, gpointer data);
+
+void
+am_pm_button_clicked (GtkButton *am_pm_button, gpointer data);
 
 void
 alarm_settings_changed_time (GtkSpinButton *spinbutton, gpointer data);
@@ -92,12 +96,30 @@ alarm_settings_changed_app (GtkComboBox *combo, gpointer data);
 
 
 #define REPEAT_LABEL	_("_Repeat: %s")
-
+#define AM_PM_LABEL_24H "24 Hr"
 
 
 /*
  * Utility functions for updating various parts of the settings dialog.
  */
+
+void
+alarm_settings_update_time_format (AlarmSettingsDialog *dialog)
+{
+    gboolean time_format_12h = prefs_time_format_12h_get (dialog->applet);
+
+    // only enable the am/pm button if alarm in 12 hour mode
+    if (dialog->alarm->type == ALARM_TYPE_CLOCK && time_format_12h) {
+        alarm_settings_update_time (dialog);
+        gtk_widget_set_sensitive (dialog->am_pm_button, TRUE);
+        gtk_spin_button_set_range (GTK_SPIN_BUTTON (dialog->hour_spin), 1, 12);
+    } else {
+        gtk_widget_set_sensitive (dialog->am_pm_button, FALSE);
+        gtk_spin_button_set_range (GTK_SPIN_BUTTON (dialog->hour_spin), 0, 23);
+        alarm_settings_update_time (dialog);
+        gtk_button_set_label (GTK_BUTTON (dialog->am_pm_button), AM_PM_LABEL_24H);
+    }
+}
 
 static void
 alarm_settings_update_type (AlarmSettingsDialog *dialog)
@@ -116,15 +138,17 @@ alarm_settings_update_type (AlarmSettingsDialog *dialog)
     g_debug ("AlarmSettingsDialog: update_type()");
 
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dialog->clock_toggle),
-		type == ALARM_TYPE_CLOCK);
-	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dialog->timer_toggle),
-		type == ALARM_TYPE_TIMER);
+            type == ALARM_TYPE_CLOCK);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dialog->timer_toggle),
+            type == ALARM_TYPE_TIMER);
 
-	if (type == ALARM_TYPE_CLOCK) {
-		gtk_widget_set_sensitive(dialog->repeat_expand, TRUE);
-	} else {
-		gtk_widget_set_sensitive(dialog->repeat_expand, FALSE);
-	}
+    if (type == ALARM_TYPE_CLOCK) {
+        gtk_widget_set_sensitive(dialog->repeat_expand, TRUE);
+    } else {
+        gtk_widget_set_sensitive(dialog->repeat_expand, FALSE);
+    }
+
+    alarm_settings_update_time_format (dialog);
 }
 
 static void
@@ -144,21 +168,42 @@ alarm_settings_update_label (AlarmSettingsDialog *dialog)
 static void
 alarm_settings_update_time (AlarmSettingsDialog *dialog)
 {
-	struct tm *tm = alarm_get_time(dialog->alarm);
-	gint hour = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (dialog->hour_spin));
-	gint min = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (dialog->min_spin));
-	gint sec = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (dialog->sec_spin));
+    struct tm *tm = alarm_get_time(dialog->alarm);
+    gint hour = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (dialog->hour_spin));
+    gint min = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (dialog->min_spin));
+    gint sec = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (dialog->sec_spin));
+    gboolean time_format_12h = prefs_time_format_12h_get (dialog->applet);
+    const gchar *am_pm_label = gtk_button_get_label (GTK_BUTTON (dialog->am_pm_button));
 
-	if (tm->tm_hour == hour && tm->tm_min == min && tm->tm_sec == sec) {
-		// No change
-		return;
-	}
+    // convert to 24 hour format if this is an alarm clock in 12 hour mode
+    if (dialog->alarm->type == ALARM_TYPE_CLOCK && time_format_12h) {
+        if (!strcmp(am_pm_label, AM_PM_LABEL_24H)) {
+            // switching from a 24 hour clock, update the time
+            hour = -1;
+        } else {
+            int is_pm = !strcmp(am_pm_label, "PM");
+            hour = HOUR_12_TO_24(hour, is_pm);
+        }
+    }
+
+    if (tm->tm_hour == hour && tm->tm_min == min && tm->tm_sec == sec) {
+        // No change
+        return;
+    }
 
     g_debug ("AlarmSettingsDialog: update_time() to %d:%d:%d", tm->tm_hour, tm->tm_min, tm->tm_sec);
-	
-	gtk_spin_button_set_value (GTK_SPIN_BUTTON (dialog->hour_spin), tm->tm_hour);
-	gtk_spin_button_set_value (GTK_SPIN_BUTTON (dialog->min_spin), tm->tm_min);
-	gtk_spin_button_set_value (GTK_SPIN_BUTTON (dialog->sec_spin), tm->tm_sec);
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (dialog->min_spin), tm->tm_min);
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (dialog->sec_spin), tm->tm_sec);
+
+    hour = tm->tm_hour;
+    // convert hour to 12 hour format and set am/pm if an alarm clock in 12-hour mode
+    if (dialog->alarm->type == ALARM_TYPE_CLOCK && time_format_12h) {
+        char *am_pm_text;
+        if (IS_HOUR_PM (hour)) am_pm_text = "PM"; else am_pm_text = "AM";
+        hour = HOUR_24_TO_12 (hour);
+        gtk_button_set_label (GTK_BUTTON (dialog->am_pm_button), am_pm_text);
+    }
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (dialog->hour_spin), hour);
 }
 
 static void
@@ -351,14 +396,14 @@ alarm_settings_update_app_command (AlarmSettingsDialog *dialog)
 static void
 alarm_settings_update (AlarmSettingsDialog *dialog)
 {
-	alarm_settings_update_type (dialog);
+    alarm_settings_update_type (dialog);
     alarm_settings_update_label (dialog);
-	alarm_settings_update_time (dialog);
-	alarm_settings_update_repeat (dialog);
-	alarm_settings_update_notify_type (dialog);
-	alarm_settings_update_sound (dialog);
+    alarm_settings_update_time_format (dialog);
+    alarm_settings_update_repeat (dialog);
+    alarm_settings_update_notify_type (dialog);
+    alarm_settings_update_sound (dialog);
     alarm_settings_update_sound_repeat (dialog);
-	alarm_settings_update_app (dialog);
+    alarm_settings_update_app (dialog);
     alarm_settings_update_app_command (dialog);
 }
 
@@ -497,6 +542,8 @@ alarm_settings_changed_type (GtkToggleButton *toggle, gpointer data)
             gtk_widget_set_sensitive(dialog->repeat_expand, FALSE);
         }
     }
+
+    alarm_settings_update_time_format (dialog);
 }
 
 void
@@ -517,12 +564,48 @@ alarm_settings_changed_label (GtkEditable *editable,
 }
 
 void
+am_pm_button_clicked (GtkButton *am_pm_button, gpointer data)
+{
+    AlarmApplet *applet = (AlarmApplet *)data;
+    AlarmSettingsDialog *dialog = applet->settings_dialog;
+    guint min, sec;
+    struct tm *tm;
+    const gchar *am_pm_label;
+    gboolean is_pm;
+
+    g_assert (dialog->alarm != NULL);
+
+    tm = alarm_get_time(dialog->alarm);
+    min = tm->tm_min;
+    sec = tm->tm_sec;
+
+    am_pm_label = gtk_button_get_label (GTK_BUTTON (dialog->am_pm_button));
+    is_pm = !strcmp(am_pm_label, "PM");
+
+    // toggle the button label
+    if (is_pm) {
+        gtk_button_set_label (GTK_BUTTON (dialog->am_pm_button), "AM");
+        is_pm = FALSE;
+    } else {
+        gtk_button_set_label (GTK_BUTTON (dialog->am_pm_button), "PM");
+        is_pm = TRUE;
+    }
+
+    // convert time to 24 hour format
+    gint hour = gtk_spin_button_get_value (GTK_SPIN_BUTTON (dialog->hour_spin));
+    hour = HOUR_12_TO_24 (hour, is_pm);
+
+    alarm_set_time (dialog->alarm, hour, min, sec);
+}
+
+void
 alarm_settings_changed_time (GtkSpinButton *spinbutton, gpointer data)
 {
     AlarmApplet *applet = (AlarmApplet *)data;
-	AlarmSettingsDialog *dialog = applet->settings_dialog;
-	guint hour, min, sec;
-	struct tm *tm;
+    AlarmSettingsDialog *dialog = applet->settings_dialog;
+    guint hour, min, sec;
+    struct tm *tm;
+    gboolean time_format_12h = prefs_time_format_12h_get (applet);
 
     g_assert (dialog->alarm != NULL);
     
@@ -533,7 +616,13 @@ alarm_settings_changed_time (GtkSpinButton *spinbutton, gpointer data)
 
     // Check which spin button emitted the signal
     if (GTK_WIDGET (spinbutton) == dialog->hour_spin) {
-		hour = gtk_spin_button_get_value (GTK_SPIN_BUTTON (dialog->hour_spin));
+        hour = gtk_spin_button_get_value (GTK_SPIN_BUTTON (dialog->hour_spin));
+        // convert to 24 hour format if this is an alarm clock in 12 hour format
+        if (dialog->alarm->type == ALARM_TYPE_CLOCK && time_format_12h) {
+            const gchar *am_pm_label = gtk_button_get_label (GTK_BUTTON (dialog->am_pm_button));
+            gboolean is_pm = !strcmp(am_pm_label, "PM");
+            hour = HOUR_12_TO_24 (hour, is_pm);
+        }
     } else if (GTK_WIDGET (spinbutton) == dialog->min_spin) {
     	min = gtk_spin_button_get_value (GTK_SPIN_BUTTON (dialog->min_spin));
     } else if (GTK_WIDGET (spinbutton) == dialog->sec_spin) {
@@ -963,11 +1052,12 @@ alarm_settings_dialog_new (AlarmApplet *applet)
 	dialog->hour_spin = GTK_WIDGET (gtk_builder_get_object (builder, "hour-spin"));
 	dialog->min_spin = GTK_WIDGET (gtk_builder_get_object (builder, "minute-spin"));
 	dialog->sec_spin = GTK_WIDGET (gtk_builder_get_object (builder, "second-spin"));
-	
-	// REPEAT SETTINGS
+	dialog->am_pm_button = GTK_WIDGET (gtk_builder_get_object (builder, "am-pm-button"));
+
+    // REPEAT SETTINGS
 	dialog->repeat_expand = GTK_WIDGET (gtk_builder_get_object (builder, "repeat-expand"));
 	dialog->repeat_label  = GTK_WIDGET (gtk_builder_get_object (builder, "repeat-label"));
-	
+
 	// The check buttons have the same name as the 3 letter
 	// string representation of the day.
 	for (r = ALARM_REPEAT_SUN, i = 0; r <= ALARM_REPEAT_SAT; r = 1 << ++i) {

--- a/src/alarm-settings.h
+++ b/src/alarm-settings.h
@@ -42,8 +42,8 @@ struct _AlarmSettingsDialog {
 	GtkWidget *dialog;
 	GtkWidget *clock_toggle, *timer_toggle;
 	GtkWidget *label_entry;
-	GtkWidget *hour_spin, *min_spin, *sec_spin;
-	
+	GtkWidget *hour_spin, *min_spin, *sec_spin, *am_pm_button;
+
 	/* Repeat */
 	GtkWidget *repeat_expand;
 	GtkWidget *repeat_label;
@@ -85,5 +85,8 @@ alarm_settings_sound_preview (GtkButton *button, gpointer data);
 
 void
 alarm_settings_dialog_response (GtkDialog *dialog, gint rid, gpointer data);
+
+void
+alarm_settings_update_time_format (AlarmSettingsDialog *dialog);
 
 #endif /*EDITALARM_H_*/

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -26,7 +26,7 @@
 
 #include <config.h>
 #include "prefs.h"
-
+#include "alarm-settings.h"
 
 void
 prefs_autostart_init (AlarmApplet *applet);
@@ -48,17 +48,29 @@ void
 prefs_show_label_changed (GConfClient *client, guint cnxn_id,
 						  GConfEntry *entry, AlarmApplet *applet);
 
+void
+prefs_time_format_12h_init (AlarmApplet *applet);
+
+void
+prefs_time_format_12h_update (AlarmApplet *applet);
+
+void
+prefs_time_format_12h_changed (GConfClient *client, guint cnxn_id,
+                               GConfEntry *entry, AlarmApplet *applet);
+
+
 /**
  * Initialize preferences dialog and friends
  */
 void
 prefs_init (AlarmApplet *applet)
 {
-	applet->prefs_dialog = GTK_DIALOG (gtk_builder_get_object(applet->ui, "preferences"));
-	applet->prefs_autostart_check = GTK_WIDGET (gtk_builder_get_object (applet->ui, "autostart-check"));
+    applet->prefs_dialog = GTK_DIALOG (gtk_builder_get_object(applet->ui, "preferences"));
+    applet->prefs_autostart_check = GTK_WIDGET (gtk_builder_get_object (applet->ui, "autostart-check"));
 
-	prefs_autostart_init (applet);
-	prefs_show_label_init (applet);
+    prefs_autostart_init (applet);
+    prefs_show_label_init (applet);
+    prefs_time_format_12h_init (applet);
 }
 
 // Ordered list of autostart files we watch for
@@ -489,6 +501,116 @@ prefs_show_label_changed (GConfClient  *client,
 
 	prefs_show_label_update (applet);
 }
+
+
+/*
+ * Initialize time format preference
+ */
+void
+prefs_time_format_12h_init (AlarmApplet *applet)
+{
+    GConfClient *client = gconf_client_get_default ();
+    GConfValue *value;
+
+    // create time format in the preferences if it doesn't yet exist
+    value = gconf_client_get(client, ALARM_GCONF_DIR "/time_format_12h", NULL);
+    if (value == NULL)
+        gconf_client_set_bool (client, ALARM_GCONF_DIR "/time_format_12h",
+                               TIME_FORMAT_12H_DEFAULT, NULL);
+    else
+        gconf_value_free (value);
+
+    // Monitor gconf key
+    gconf_client_notify_add (
+            client, ALARM_GCONF_DIR "/time_format_12h",
+            (GConfClientNotifyFunc) prefs_time_format_12h_changed,
+            applet, NULL, NULL);
+
+    // Update toggle button state
+    prefs_time_format_12h_update (applet);
+
+    g_object_unref(client);
+}
+
+/*
+ * Get the current time format state from GConf
+ */
+gboolean
+prefs_time_format_12h_get (AlarmApplet *applet)
+{
+    GConfClient *client = gconf_client_get_default ();
+    GConfValue *value;
+    gboolean state;
+
+    // Get config value
+    value = gconf_client_get (client, ALARM_GCONF_DIR "/time_format_12h", NULL);
+    if (value == NULL) {
+        g_warning ("Get %s failed", ALARM_GCONF_DIR "/time_format_12h");
+        g_object_unref(client);
+        // fall back on preferences window setting or, last resort, default
+        if (applet->action_toggle_time_format_12h == NULL)
+            return TIME_FORMAT_12H_DEFAULT;
+        else
+            return gtk_toggle_action_get_active (applet->action_toggle_time_format_12h);
+    }
+
+    state = gconf_value_get_bool (value);
+    gconf_value_free (value);
+    g_object_unref(client);
+
+    return state;
+}
+
+/*
+ * Set time format state in GConf
+ */
+void
+prefs_time_format_12h_set (AlarmApplet *applet, gboolean state)
+{
+    gboolean current_state = prefs_time_format_12h_get (applet);
+
+    if (current_state == state) {
+        // No change
+        return;
+    }
+
+    // Set config value
+    GConfClient *client = gconf_client_get_default ();
+    gconf_client_set_bool (client, ALARM_GCONF_DIR "/time_format_12h", state, NULL);
+    g_object_unref(client);
+}
+
+/*
+ * Update time format toggle button state
+ */
+void
+prefs_time_format_12h_update (AlarmApplet *applet)
+{
+    gboolean state = gtk_toggle_action_get_active (applet->action_toggle_time_format_12h);
+    gboolean new_state = prefs_time_format_12h_get (applet);
+
+    g_debug ("Preferences: Time format update: new state: %d", new_state);
+
+    if (state != new_state) {
+        gtk_toggle_action_set_active (applet->action_toggle_time_format_12h, new_state);
+        // in case a settings dialog is currently open for an alarm
+        if (applet->settings_dialog->alarm != NULL) {
+            alarm_settings_update_time_format (applet->settings_dialog);
+        }
+    }
+}
+
+void
+prefs_time_format_12h_changed (GConfClient  *client,
+                          guint         cnxn_id,
+                          GConfEntry   *entry,
+                          AlarmApplet  *applet)
+{
+    g_debug ("time_format_12h_changed");
+
+    prefs_time_format_12h_update (applet);
+}
+
 
 /**
  * Show preferences dialog

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -26,6 +26,8 @@
 
 #include "alarm-applet.h"
 
+#define TIME_FORMAT_12H_DEFAULT FALSE
+
 void
 prefs_init (AlarmApplet *applet);
 
@@ -43,5 +45,12 @@ prefs_show_label_get (AlarmApplet *applet);
 
 void
 prefs_show_label_set (AlarmApplet *applet, gboolean state);
+
+gboolean
+prefs_time_format_12h_get (AlarmApplet *applet);
+
+void
+prefs_time_format_12h_set (AlarmApplet *applet, gboolean state);
+
 
 #endif /*PREFS_H_*/

--- a/src/util.h
+++ b/src/util.h
@@ -76,4 +76,16 @@ unblock_list (GList *instances, gpointer func);
                                        G_SIGNAL_MATCH_FUNC,   \
                                        0, 0, NULL, (func), NULL)
 
+/* Converts hour from 12 hour format (am/pm) to 24 hour format */
+#define HOUR_12_TO_24(hour, is_pm) \
+    is_pm ? (hour != 12 ? hour + 12 : hour) : (hour == 12 ? 0 : hour)
+
+/* Converts hour from 24 hour format to 12 hour format (am/pm) */
+#define HOUR_24_TO_12(hour) \
+    hour > 12 ? hour - 12 : (hour < 1 ? 12 : hour);
+
+/* True if the hour (in 24 hour format) is in the PM, false if AM */
+# define IS_HOUR_PM(hour) \
+    hour > 12 ? TRUE : (hour < 12 ? FALSE : TRUE)
+
 #endif /*UTIL_H_*/


### PR DESCRIPTION
New option in preference dialog and gconf to use an AM/PM (12 hour) time
format instead of 24 hour for setting and viewing alarm clock times
   * Default is 24 hour (AM/PM format off)
   * Hour setting for timers still from 0 to 23

Fixed a few indentation inconsistencies