### PR TITLE
fix build on gcc-10 (-fno-common)

### DIFF
--- a/src/alarm-applet.h
+++ b/src/alarm-applet.h
@@ -46,7 +46,7 @@ G_BEGIN_DECLS
 
 typedef struct _AlarmApplet AlarmApplet;
 
-GHashTable *app_command_map;
+extern GHashTable *app_command_map;
 
 void alarm_applet_label_update (AlarmApplet *applet);
 void alarm_applet_clear_alarms (AlarmApplet *applet);


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: prefs.o:src/alarm-applet.h:49: multiple definition of
      `app_command_map'; alarm-applet.o:src/alarm-applet.h:49: first defined here

Variable definition is already present in .c file. The change leaves
only declaration in .h file.